### PR TITLE
Update OrbitControl.js adding maxPanLength and minPanLength

### DIFF
--- a/examples/jsm/controls/OrbitControls.js
+++ b/examples/jsm/controls/OrbitControls.js
@@ -55,6 +55,12 @@ class OrbitControls extends EventDispatcher {
 		// If set, the interval [ min, max ] must be a sub-interval of [ - 2 PI, 2 PI ], with ( max - min < 2 PI )
 		this.minAzimuthAngle = - Infinity; // radians
 		this.maxAzimuthAngle = Infinity; // radians
+		
+		// Limit the camera's movement within a spherical volume
+		// Set maxPanRadius to ensure the camera doesn't travel further than maxPanRadius from the origin
+		// Set minPanRadius to force the camera to stay at least minPanRadius from the origin.
+		this.minPanRadius = 0;
+		this.maxPanRadius = Infinity;
 
 		// Set to true to enable damping (inertia)
 		// If damping is enabled, you must call controls.update() in your animation loop
@@ -241,6 +247,9 @@ class OrbitControls extends EventDispatcher {
 					scope.target.add( panOffset );
 
 				}
+				
+				// Limit the camera's movement within a spherical volume
+				scope.target.clampLength(scope.minPanRadius, scope.maxPanRadius);
 
 				offset.setFromSpherical( spherical );
 


### PR DESCRIPTION
Add the ability to optionally limit the orbit camera's target movement within a spherical volume with maxPanLength

**Description**
If you are working in a scene with known bounds, it would be nice to be able to constrain the camera target so that you don't get lost or end up looking at emptiness.

This behaviour would not suitable for all scenes and should be optional.

This implementation limits the camera target so that it cannot leave a spherical volume as defined by maxPanRadius. It is set to infinity by default so it takes no effect unless explicity set.

To use:
Set maxPanRadius to ensure the camera target doesn't travel further than maxPanRadius from the origin
Set minPanRadius to force the camera target to stay at least minPanRadius from the origin.

